### PR TITLE
Ensure that the tests pass on machines where .m2 isn't prepopulated.

### DIFF
--- a/src/it/settings.xml
+++ b/src/it/settings.xml
@@ -16,6 +16,12 @@
                         <enabled>true</enabled>
                     </snapshots>
                 </repository>
+                <repository>
+                    <id>vertispan-releases</id>
+                    <name>Vertispan hosted artifacts-releases</name>
+                    <url>https://repo.vertispan.com/j2cl</url>
+                </repository>
+
             </repositories>
             <pluginRepositories>
                 <pluginRepository>


### PR DESCRIPTION
This isn't a very nice fix, but the extraArtifacts config option doesn't
seem to do what it says it should. This should be cleaner once we have
the various basics in maven central