### PR TITLE
improved test log readability

### DIFF
--- a/src/main/java/net/cardosi/mojo/TestMojo.java
+++ b/src/main/java/net/cardosi/mojo/TestMojo.java
@@ -80,6 +80,9 @@ public class TestMojo extends AbstractGwt3BuildMojo implements ClosureBuildConfi
         if (skipTests) {
             return;
         }
+
+        Map<String, String> failedTests = new HashMap<>();
+
         PluginDescriptor pluginDescriptor = (PluginDescriptor) getPluginContext().get("pluginDescriptor");
         String pluginVersion = pluginDescriptor.getVersion();
 
@@ -130,7 +133,7 @@ public class TestMojo extends AbstractGwt3BuildMojo implements ClosureBuildConfi
 
             for (ClosureBuildConfiguration config : getTestConfigs(this, tests, project, includes, excludes)) {
                 e.registerAsApp(config).join();
-
+                getLog().info("Test started: " + ((TestConfig)config).getTest());
                 // write a simple html file to that output dir
                 //TODO parallelize this - run once each is done, possibly concurrently
                 //TODO don't fail on the first test that doesn't work
@@ -147,8 +150,6 @@ public class TestMojo extends AbstractGwt3BuildMojo implements ClosureBuildConfi
                 } catch (IOException ex) {
                     throw new UncheckedIOException(ex);
                 }
-
-
                 // assuming that was successful, start htmlunit to run the test
                 WebDriver driver = null;
                 try {
@@ -160,14 +161,16 @@ public class TestMojo extends AbstractGwt3BuildMojo implements ClosureBuildConfi
                             .withMessage("Tests failed to finish in timeout")
                             .pollingEvery(Duration.ofMillis(100))
                             .until(d -> isFinished(d));
-
                     // check for success
                     if (!isSuccess(driver)) {
-                        System.err.println("At least one test failed, please try manually");
-                        throw new MojoFailureException("At least one test failed, please try again manually: " + startupHtmlFile);
+                        failedTests.put(((TestConfig) config).getTest(), startupHtmlFile);
+                        getLog().error("Test failed!");
                     } else {
-                        System.err.println("Tests passed!");
+                        getLog().info("Test passed!");
                     }
+                } catch (Exception ex) {
+                    failedTests.put(((TestConfig) config).getTest(), startupHtmlFile);
+                    getLog().error("Test failed!");
                 } finally {
                     if (driver != null) {
                         driver.quit();
@@ -176,6 +179,13 @@ public class TestMojo extends AbstractGwt3BuildMojo implements ClosureBuildConfi
             }
         } catch (ProjectBuildingException | IOException e) {
             throw new MojoExecutionException("Failed to build project structure", e);
+        }
+
+        if(failedTests.isEmpty()) {
+            getLog().info("All tests were passed successfully!");
+        } else {
+            failedTests.forEach((name, startupHtmlFile) -> getLog().error(String.format("Test %s failed, please try manually %s", name, startupHtmlFile)));
+            throw new MojoFailureException("At least one test failed");
         }
     }
 
@@ -254,6 +264,7 @@ public class TestMojo extends AbstractGwt3BuildMojo implements ClosureBuildConfi
     }
 
     private static class TestConfig implements ClosureBuildConfiguration {
+
         private final String test;
         private final ClosureBuildConfiguration wrapped;
 
@@ -295,6 +306,10 @@ public class TestMojo extends AbstractGwt3BuildMojo implements ClosureBuildConfi
         @Override
         public String getCompilationLevel() {
             return wrapped.getCompilationLevel();
+        }
+
+        public String getTest() {
+            return test;
         }
     }
 }


### PR DESCRIPTION
it's difficult to analyze the test logs :
```
Starting ChromeDriver 76.0.3809.132 (fd1acc410994a7a68ac25bc77513d443f3130860-refs/branch-heads/3809@{#1035}) on port 18372
Only local connections are allowed.
Please protect ports used by ChromeDriver and related test frameworks to prevent access by malicious code.
Sep 17, 2019 9:21:25 PM org.openqa.selenium.remote.ProtocolHandshake createSession
INFO: Detected dialect: W3C
```

i am proposing to run all tests and do a report of failed tests at the end. I also think it could be nice to to print test name and result during the run.

```
...

Test started: org.gwtproject.touch.client.TouchScrollTest
Starting ChromeDriver 76.0.3809.132 (fd1acc410994a7a68ac25bc77513d443f3130860-refs/branch-heads/3809@{#1035}) on port 13813
Only local connections are allowed.
Please protect ports used by ChromeDriver and related test frameworks to prevent access by malicious code.
Sep 18, 2019 2:12:49 PM org.openqa.selenium.remote.ProtocolHandshake createSession
INFO: Detected dialect: W3C
Test passed!
Test org.gwtproject.cell.client.AbstractCellTest failed, please try manually /home/treblereel/workspace/gwt/gwt-widgets/gwt-widgets-tests/target/gwt-widgets-tests-1.0-SNAPSHOT-test/gwt-org.gwtproject.cell.client.AbstractCellTest.html 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE

```