### PR TITLE
Hash sha1 String fix and tidy up.

### DIFF
--- a/src/main/java/net/cardosi/mojo/ClosureBuildConfiguration.java
+++ b/src/main/java/net/cardosi/mojo/ClosureBuildConfiguration.java
@@ -31,15 +31,15 @@ public interface ClosureBuildConfiguration {
         //TODO externs need to have their _contents_ hashed instead
 
         Hash hash = new Hash();
-        hash.append(getClasspathScope().getBytes());
-        getEntrypoint().forEach(s -> hash.append(s.getBytes()));
-        getEntrypoint().forEach(s -> hash.append(s.getBytes()));
-        new TreeMap<>(getDefines()).forEach((key, value) -> {
-            hash.append(key.getBytes());
-            hash.append(value.getBytes());
+        hash.append(getClasspathScope());
+        getEntrypoint().forEach(s -> hash.append(s));
+        new TreeMap<>(getDefines())
+                .forEach((key, value) -> {
+                    hash.append(key);
+                    hash.append(value);
         });
         // not considering webappdir or script filename for now, should just copy the output at the end every time
-        hash.append(getCompilationLevel().getBytes());
+        hash.append(getCompilationLevel());
 
         return hash.toString();
     }

--- a/src/main/java/net/cardosi/mojo/Hash.java
+++ b/src/main/java/net/cardosi/mojo/Hash.java
@@ -2,12 +2,16 @@ package net.cardosi.mojo;
 
 import org.apache.commons.codec.binary.Hex;
 
+import java.nio.charset.Charset;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
+/**
+ * Builds a SHA1 composed of several inputs, including string parameters used during transpiling and file contents.
+ */
 public class Hash {
     private final MessageDigest digest;
-    private String result;
+    private String hash;
 
     public Hash() {
         try {
@@ -17,15 +21,23 @@ public class Hash {
         }
     }
 
-    public void append(byte[] content) {
-        digest.update(content);
-
+    public void append(final String text){
+        this.append(text.getBytes(Charset.defaultCharset()));
     }
+
+    public void append(final byte[] content) {
+        digest.update(content);
+        this.hash = null; // result is now out of sync and needs to be recomputed.
+    }
+
+    /**
+     * The builder that returns the SHA as hex digits.
+     */
     @Override
     public String toString() {
-        if (result == null) {
-            result = Hex.encodeHexString(digest.digest());
+        if (null == hash) {
+            hash = Hex.encodeHexString(digest.digest());
         }
-        return result;
+        return hash;
     }
 }

--- a/src/main/java/net/cardosi/mojo/cache/CachedProject.java
+++ b/src/main/java/net/cardosi/mojo/cache/CachedProject.java
@@ -698,8 +698,8 @@ public class CachedProject {
                     .collect(Collectors.toList());
         }, (hashes, ignore) -> {
             Hash hash = new Hash();
-            hash.append(diskCache.getPluginVersion().getBytes(Charset.forName("UTF-8")));
-            hashes.forEach(h -> hash.append(h.getBytes(Charset.forName("UTF-8"))));
+            hash.append(diskCache.getPluginVersion());
+            hashes.forEach(hash::append);
             try {
                 if (!compileSourceRoots.isEmpty()) {
                     for (String compileSourceRoot : compileSourceRoots) {


### PR DESCRIPTION
- Hash.toString cached sha in hex form and never cleared when more stuff appended.
- Introduced helper append(String) to cleanup call-sites
- removed duplicate "Entrypoint" hashing