### PR TITLE
Feature/cached project logging readability improvements

### DIFF
--- a/src/main/java/net/cardosi/mojo/BuildMojo.java
+++ b/src/main/java/net/cardosi/mojo/BuildMojo.java
@@ -81,7 +81,7 @@ public class BuildMojo extends AbstractBuildMojo implements ClosureBuildConfigur
     protected String webappDirectory;
 
     @Parameter
-    protected List<String> externs = new ArrayList<>();
+    protected Set<String> externs = new TreeSet<>();
 
     @Parameter
     protected List<String> entrypoint = new ArrayList<>();
@@ -90,7 +90,7 @@ public class BuildMojo extends AbstractBuildMojo implements ClosureBuildConfigur
     protected String compilationLevel;
 
     @Parameter
-    protected Map<String, String> defines = new HashMap<>();
+    protected Map<String, String> defines = new TreeMap<>();
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
@@ -150,7 +150,7 @@ public class BuildMojo extends AbstractBuildMojo implements ClosureBuildConfigur
     }
 
     @Override
-    public List<String> getExterns() {
+    public Set<String> getExterns() {
         return externs;
     }
 

--- a/src/main/java/net/cardosi/mojo/ClosureBuildConfiguration.java
+++ b/src/main/java/net/cardosi/mojo/ClosureBuildConfiguration.java
@@ -2,6 +2,7 @@ package net.cardosi.mojo;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 
 /**
@@ -15,7 +16,7 @@ public interface ClosureBuildConfiguration {
 
     List<String> getEntrypoint();
 
-    List<String> getExterns();
+    Set<String> getExterns();
 
     Map<String, String> getDefines();
 
@@ -33,7 +34,7 @@ public interface ClosureBuildConfiguration {
         Hash hash = new Hash();
         hash.append(getClasspathScope());
         getEntrypoint().forEach(s -> hash.append(s));
-        new TreeMap<>(getDefines())
+        getDefines()
                 .forEach((key, value) -> {
                     hash.append(key);
                     hash.append(value);

--- a/src/main/java/net/cardosi/mojo/TestMojo.java
+++ b/src/main/java/net/cardosi/mojo/TestMojo.java
@@ -53,7 +53,7 @@ public class TestMojo extends AbstractBuildMojo implements ClosureBuildConfigura
     protected String webappDirectory;
 
     @Parameter
-    protected List<String> externs = new ArrayList<>();
+    protected Set<String> externs = new TreeSet<>();
 
     @Parameter
     protected List<String> tests;
@@ -62,7 +62,7 @@ public class TestMojo extends AbstractBuildMojo implements ClosureBuildConfigura
     protected String compilationLevel;
 
     @Parameter
-    protected Map<String, String> defines = new HashMap<>();
+    protected Map<String, String> defines = new TreeMap<>();
 
     @Parameter(defaultValue = "false", property = "maven.test.skip")
     protected boolean skipTests;
@@ -239,7 +239,7 @@ public class TestMojo extends AbstractBuildMojo implements ClosureBuildConfigura
     }
 
     @Override
-    public List<String> getExterns() {
+    public Set<String> getExterns() {
         return externs;
     }
 
@@ -284,7 +284,7 @@ public class TestMojo extends AbstractBuildMojo implements ClosureBuildConfigura
         }
 
         @Override
-        public List<String> getExterns() {
+        public Set<String> getExterns() {
             return wrapped.getExterns();
         }
 

--- a/src/main/java/net/cardosi/mojo/XmlDomClosureConfig.java
+++ b/src/main/java/net/cardosi/mojo/XmlDomClosureConfig.java
@@ -47,15 +47,19 @@ public class XmlDomClosureConfig implements ClosureBuildConfiguration {
     }
 
     @Override
-    public List<String> getExterns() {
+    public Set<String> getExterns() {
         Xpp3Dom externs = dom.getChild("externs");
 
-        return externs == null ? Collections.emptyList() : Arrays.stream(externs.getChildren()).map(Xpp3Dom::getValue).collect(Collectors.toList());
+        return externs == null ?
+                Collections.emptySet() :
+                Arrays.stream(externs.getChildren())
+                        .map(Xpp3Dom::getValue)
+                        .collect(Collectors.toCollection(TreeSet::new));
     }
 
     @Override
     public Map<String, String> getDefines() {
-        Map<String, String> defines = new HashMap<>();
+        Map<String, String> defines = new TreeMap<>();
 
         Xpp3Dom elt = dom.getChild("defines");
 

--- a/src/main/java/net/cardosi/mojo/cache/CachedProject.java
+++ b/src/main/java/net/cardosi/mojo/cache/CachedProject.java
@@ -27,6 +27,7 @@ import java.util.*;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -57,7 +58,7 @@ public class CachedProject {
     private final List<CachedProject> dependents = new ArrayList<>();
     private final List<String> compileSourceRoots;
 
-    private final Map<String, CompletableFuture<TranspiledCacheEntry>> steps = Collections.synchronizedMap(new HashMap<>());
+    private final Map<String, CompletableFuture<TranspiledCacheEntry>> steps = new ConcurrentHashMap<>();
 
     private boolean ignoreJavacFailure;
     private Set<ClosureBuildConfiguration> registeredBuildTerminals = new HashSet<>();


### PR DESCRIPTION
The goal of this is to improve the logging currently in the plugin by introducing some consistency such as prefixing all log entries 

```
$artifact $step $message
```

selected examples of messages below...
```
com.vertispan.j2cl:gwt-internal-annotations:0.3-SNAPSHOT HASH Finished in 17ms
org.opentest4j:opentest4j:1.1.1 HASH Finished in 3ms
com.vertispan.jsinterop:base:1.0.0-20190611.161520-30 HASH Finished in 7ms
org.junit.platform:junit-platform-commons:1.4.0 HASH Finished in 12ms
org.junit.platform:junit-platform-engine:1.4.0 HASH Finished in 31ms
org.junit.jupiter:junit-jupiter-api:5.4.0 HASH Finished in 32ms
org.junit.jupiter:junit-jupiter-engine:5.4.0 HASH Finished in 28ms
...
mp12:j2cl-experiment:1.0-SNAPSHOT TRANSPILE_SOURCES Failed java.util.concurrent.CompletionException:java.lang.IllegalStateException: javac failed, check log
...
mp12:j2cl-experiment:1.0-SNAPSHOT ASSEMBLE_OUTPUT Failed java.util.concurrent.CompletionException:java.lang.IllegalStateException: javac failed, check log
```

before the output was horrible for several reasons.
- the artifact could be anywhere in the line of text, now its at the start
- step was lower case, now its 2nd after artifact and UPPERCASE making it very easy to spot.
- step was also never in the same place again meaning one had to really read the line to find it.

The next comment will contain a much fuller log snippet with an intended failure, demonstrating its now "easier" to find individual steps as they execute / complete / fail etc.