### PR TITLE
Fix charset issue for test runner

### DIFF
--- a/src/main/resources/junit.html
+++ b/src/main/resources/junit.html
@@ -1,6 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html>
 <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>j2cl-maven-plugin test runner</title>
 </head>
 <body>


### PR DESCRIPTION
When running junit.html there is no info about the content encoding of
the html file. On os with no UTF-8 standard encoding (like Windows) this
results in interpreting the file with a non-UTF-8-Encoding. This is also
true for all referenced js-files which ends up in charset issues. This
commit fixes this issue by setting charset to UTF-8.