### PR TITLE
Parameterize Closure's language_out setting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.vertispan.j2cl</groupId>
   <artifactId>j2cl-maven-plugin</artifactId>
-  <version>0.16-SNAPSHOT</version>
+  <version>0.17-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>J2CL Maven Plugin</name>

--- a/src/it/hello-world-web-components/pom.xml
+++ b/src/it/hello-world-web-components/pom.xml
@@ -1,0 +1,69 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>hello-world-custom-elements</groupId>
+  <artifactId>hello-world-custom-elements</artifactId>
+  <version>1.0</version>
+  <packaging>war</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.jsinterop</groupId>
+      <artifactId>jsinterop-annotations</artifactId>
+      <version>1.0.2</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.elemental2</groupId>
+      <artifactId>elemental2-core</artifactId>
+      <version>1.1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.elemental2</groupId>
+      <artifactId>elemental2-dom</artifactId>
+      <version>1.1.0</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>build-js</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>build</goal>
+            </goals>
+            <configuration>
+              <languageOut>ECMASCRIPT_2017</languageOut>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.6.1</version>
+          <configuration>
+            <source>1.8</source>
+            <target>1.8</target>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+  <repositories>
+    <repository>
+      <id>google-snapshots</id>
+      <url>https://oss.sonatype.org/content/repositories/google-snapshots/</url>
+    </repository>
+  </repositories>
+</project>

--- a/src/it/hello-world-web-components/src/main/java/example/helloworld/HelloWorld.java
+++ b/src/it/hello-world-web-components/src/main/java/example/helloworld/HelloWorld.java
@@ -1,0 +1,29 @@
+package example.helloworld;
+
+import elemental2.dom.HTMLElement;
+import elemental2.dom.HTMLTemplateElement;
+import jsinterop.annotations.JsType;
+
+import static elemental2.dom.DomGlobal.customElements;
+import static elemental2.dom.DomGlobal.document;
+
+@JsType
+public class HelloWorld extends HTMLElement {
+  private static final HTMLTemplateElement TEMPLATE =
+      (HTMLTemplateElement) document.getElementById("hello-world");
+
+  private static final AttachShadowOptionsType SHADOW_OPTIONS;
+  static {
+    SHADOW_OPTIONS = AttachShadowOptionsType.create();
+    SHADOW_OPTIONS.setMode("open");
+  }
+
+  public HelloWorld() {
+    attachShadow(SHADOW_OPTIONS)
+        .appendChild(TEMPLATE.content.cloneNode(true));
+  }
+
+  public static void main() {
+    customElements.define("hello-world", HelloWorld.class);
+  }
+}

--- a/src/it/hello-world-web-components/src/main/java/example/helloworld/app.js
+++ b/src/it/hello-world-web-components/src/main/java/example/helloworld/app.js
@@ -1,0 +1,5 @@
+goog.module('example.helloworld.app');
+
+const HelloWorld = goog.require("example.helloworld.HelloWorld");
+
+HelloWorld.main();

--- a/src/it/hello-world-web-components/src/main/webapp/WEB-INF/web.xml
+++ b/src/it/hello-world-web-components/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,1 @@
+<web-app></web-app>

--- a/src/it/hello-world-web-components/src/main/webapp/index.html
+++ b/src/it/hello-world-web-components/src/main/webapp/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Hello Web Components</title>
+
+  <template id="hello-world">
+    <p>Hello World, Web Components</p>
+  </template>
+
+  <script type="application/javascript" src="hello-world-web-components/hello-world-web-components.js"></script>
+</head>
+<body>
+<hello-world></hello-world>
+</body>
+</html>

--- a/src/main/java/net/cardosi/mojo/BuildMojo.java
+++ b/src/main/java/net/cardosi/mojo/BuildMojo.java
@@ -1,5 +1,6 @@
 package net.cardosi.mojo;
 
+import com.google.javascript.jscomp.CompilerOptions;
 import com.google.javascript.jscomp.DependencyOptions;
 import net.cardosi.mojo.cache.CachedProject;
 import net.cardosi.mojo.cache.DiskCache;
@@ -147,6 +148,13 @@ public class BuildMojo extends AbstractBuildMojo implements ClosureBuildConfigur
     @Parameter(defaultValue = "ADVANCED_OPTIMIZATIONS", property = "compilationLevel")
     protected String compilationLevel;
 
+    /**
+     * ECMAScript language level of generated JavasScript. Values correspond to the Closure Compiler reference:
+     * https://github.com/google/closure-compiler/wiki/Flags-and-Options
+     */
+    @Parameter(defaultValue = "ECMASCRIPT5", property = "languageOut")
+    protected String languageOut;
+
     @Parameter
     protected Map<String, String> defines = new TreeMap<>();
 
@@ -259,6 +267,11 @@ public class BuildMojo extends AbstractBuildMojo implements ClosureBuildConfigur
     @Override
     public String getCompilationLevel() {
         return compilationLevel;
+    }
+
+    @Override
+    public String getLanguageOut() {
+        return languageOut;
     }
 
     @Override

--- a/src/main/java/net/cardosi/mojo/ClosureBuildConfiguration.java
+++ b/src/main/java/net/cardosi/mojo/ClosureBuildConfiguration.java
@@ -32,6 +32,8 @@ public interface ClosureBuildConfiguration {
     @Deprecated
     DependencyOptions.DependencyMode getDependencyMode();
 
+    String getLanguageOut();
+
     boolean getRewritePolyfills();
 
     boolean getCheckAssertions();
@@ -57,6 +59,8 @@ public interface ClosureBuildConfiguration {
         hash.append(getInitialScriptFilename());
 
         hash.append(getCompilationLevel());
+
+        hash.append(getLanguageOut());
 
         BitSet flags = new BitSet();
         flags.set(0, getRewritePolyfills());

--- a/src/main/java/net/cardosi/mojo/TestMojo.java
+++ b/src/main/java/net/cardosi/mojo/TestMojo.java
@@ -103,6 +103,13 @@ public class TestMojo extends AbstractBuildMojo implements ClosureBuildConfigura
     @Parameter(defaultValue = CachedProject.BUNDLE_JAR, property = "compilationLevel")
     protected String compilationLevel;
 
+    /**
+     * ECMAScript language level of generated JavasScript. Values correspond to the Closure Compiler reference:
+     * https://github.com/google/closure-compiler/wiki/Flags-and-Options
+     */
+    @Parameter(defaultValue = "ECMASCRIPT5", property = "languageOut")
+    protected String languageOut;
+
     @Parameter
     protected Map<String, String> defines = new TreeMap<>();
 
@@ -454,6 +461,11 @@ public class TestMojo extends AbstractBuildMojo implements ClosureBuildConfigura
     }
 
     @Override
+    public String getLanguageOut() {
+        return languageOut;
+    }
+
+    @Override
     public DependencyOptions.DependencyMode getDependencyMode() {
         return DependencyOptions.DependencyMode.valueOf(dependencyMode);
     }
@@ -524,6 +536,11 @@ public class TestMojo extends AbstractBuildMojo implements ClosureBuildConfigura
         @Override
         public String getCompilationLevel() {
             return wrapped.getCompilationLevel();
+        }
+
+        @Override
+        public String getLanguageOut() {
+            return wrapped.getLanguageOut();
         }
 
         @Override

--- a/src/main/java/net/cardosi/mojo/WatchMojo.java
+++ b/src/main/java/net/cardosi/mojo/WatchMojo.java
@@ -77,6 +77,13 @@ public class WatchMojo extends AbstractBuildMojo {
     protected String compilationLevel;
 
     /**
+     * ECMAScript language level of generated JavasScript. Values correspond to the Closure Compiler reference:
+     * https://github.com/google/closure-compiler/wiki/Flags-and-Options
+     */
+    @Parameter(defaultValue = "ECMASCRIPT5", property = "languageOut")
+    protected String languageOut;
+
+    /**
      * Whether or not to leave Java assert checks in the compiled code. In j2cl:watch, defaults to true. Has no
      * effect when the compilation level isn't set to ADVANCED_OPTIMIZATIONS, assertions will always remain
      * enabled.
@@ -180,7 +187,7 @@ public class WatchMojo extends AbstractBuildMojo {
 //                                apps.add(e);
                             } else if (goal.equals("build") && shouldCompileBuild()) {
                                 System.out.println("Found build " + execution);
-                                XmlDomClosureConfig config = new XmlDomClosureConfig(configuration, Artifact.SCOPE_COMPILE_PLUS_RUNTIME, compilationLevel, rewritePolyfills, reactorProject.getArtifactId(), DependencyOptions.DependencyMode.SORT_ONLY, enableSourcemaps, webappDirectory);
+                                XmlDomClosureConfig config = new XmlDomClosureConfig(configuration, Artifact.SCOPE_COMPILE_PLUS_RUNTIME, compilationLevel, languageOut, rewritePolyfills, reactorProject.getArtifactId(), DependencyOptions.DependencyMode.SORT_ONLY, enableSourcemaps, webappDirectory);
 
                                 // Load up all the dependencies in the requested scope for the current project
                                 CachedProject p = loadDependenciesIntoCache(reactorProject.getArtifact(), reactorProject, true, projectBuilder, request, diskCache, pluginVersion, projects, Artifact.SCOPE_COMPILE_PLUS_RUNTIME, getDependencyReplacements(), "* ");

--- a/src/main/java/net/cardosi/mojo/XmlDomClosureConfig.java
+++ b/src/main/java/net/cardosi/mojo/XmlDomClosureConfig.java
@@ -10,6 +10,7 @@ public class XmlDomClosureConfig implements ClosureBuildConfiguration {
     private final Xpp3Dom dom;
     private final String defaultScope;
     private final String defaultCompilationLevel;
+    private final String defaultLanguageOut;
     private final boolean defaultRewritePolyfills;
     private final String defaultInitialScriptFilename;
 
@@ -24,16 +25,18 @@ public class XmlDomClosureConfig implements ClosureBuildConfiguration {
      * @param dom the dom from the plugin invocation
      * @param defaultScope the expected scope based on the goal detected
      * @param defaultCompilationLevel the default compilation level based on the goal detected
+     * @param defaultLanguageOut the default output langague level based on the goal detected
      * @param defaultRewritePolyfills whether or not closure should rewrite polyfills by default
      * @param artifactId the artifactId of the project being wrapped here
      * @param defaultDependencyMode (deprecated, will be gone soon)
      * @param defaultSourcemapsEnabled true if sourcemaps should be enabled by default
      * @param defaultWebappDirectory the current invocation's launch dir, so we all serve from the same place
      */
-    public XmlDomClosureConfig(Xpp3Dom dom, String defaultScope, String defaultCompilationLevel, boolean defaultRewritePolyfills, String artifactId, DependencyOptions.DependencyMode defaultDependencyMode, boolean defaultSourcemapsEnabled, String defaultWebappDirectory) {
+    public XmlDomClosureConfig(Xpp3Dom dom, String defaultScope, String defaultCompilationLevel, String defaultLanguageOut, boolean defaultRewritePolyfills, String artifactId, DependencyOptions.DependencyMode defaultDependencyMode, boolean defaultSourcemapsEnabled, String defaultWebappDirectory) {
         this.dom = dom;
         this.defaultScope = defaultScope;
         this.defaultCompilationLevel = defaultCompilationLevel;
+        this.defaultLanguageOut = defaultLanguageOut;
         this.defaultRewritePolyfills = defaultRewritePolyfills;
         this.defaultInitialScriptFilename = artifactId + "/" + artifactId + ".js";
         this.defaultDependencyMode = defaultDependencyMode;
@@ -110,6 +113,13 @@ public class XmlDomClosureConfig implements ClosureBuildConfiguration {
         //if users want this controlled globally, properties are prob the best option
         Xpp3Dom elt = dom.getChild("compilationLevel");
         return elt == null ? defaultCompilationLevel : elt.getValue();
+    }
+
+    @Override
+    public String getLanguageOut() {
+        //if users want this controlled globally, properties are prob the best option
+        Xpp3Dom elt = dom.getChild("languageOut");
+        return elt == null ? defaultLanguageOut : elt.getValue();
     }
 
     @Override

--- a/src/main/java/net/cardosi/mojo/cache/CachedProject.java
+++ b/src/main/java/net/cardosi/mojo/cache/CachedProject.java
@@ -5,6 +5,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.j2cl.common.FrontendUtils;
 import com.google.javascript.jscomp.*;
+import com.google.javascript.jscomp.CompilerOptions.LanguageMode;
 import net.cardosi.mojo.ClosureBuildConfiguration;
 import net.cardosi.mojo.Hash;
 import net.cardosi.mojo.tools.*;
@@ -372,6 +373,8 @@ public class CachedProject {
 
             CompilationLevel compilationLevel = CompilationLevel.fromString(config.getCompilationLevel());
 
+            LanguageMode languageOut = LanguageMode.fromString(config.getLanguageOut());
+
             //TODO pick another location if sourcemaps aren't going to be used
 
             File sources;
@@ -414,6 +417,7 @@ public class CachedProject {
             boolean success = closureCompiler.compile(
                     compilationLevel,
                     config.getDependencyMode(),
+                    languageOut,
                     sources,
                     diskCache.getExtraJsZips(),
                     config.getEntrypoint(),
@@ -466,9 +470,12 @@ public class CachedProject {
 
         Preconditions.checkArgument(config.getDependencyMode() == DependencyOptions.DependencyMode.SORT_ONLY, "With compilationLevel=" + BUNDLE_JAR + " only dependencyMode=SORT_ONLY is supported");
 
+        LanguageMode languageOut = LanguageMode.valueOf(config.getLanguageOut());
+
         boolean success = closureCompiler.compile(
                 CompilationLevel.BUNDLE,
                 DependencyOptions.DependencyMode.SORT_ONLY,
+                languageOut,
                 null,
                 diskCache.getExtraJsZips(),
                 Collections.emptyList(),
@@ -642,6 +649,7 @@ public class CachedProject {
             boolean success = closureCompiler.compile(
                     CompilationLevel.BUNDLE,
                     DependencyOptions.DependencyMode.SORT_ONLY,
+                    LanguageMode.STABLE_OUT,
                     sources,
                     Collections.emptyList(),
                     Collections.emptyList(),

--- a/src/main/java/net/cardosi/mojo/tools/Closure.java
+++ b/src/main/java/net/cardosi/mojo/tools/Closure.java
@@ -2,6 +2,7 @@ package net.cardosi.mojo.tools;
 
 import com.google.javascript.jscomp.*;
 import com.google.javascript.jscomp.Compiler;
+import com.google.javascript.jscomp.parsing.Config;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -20,6 +21,7 @@ public class Closure {
     public boolean compile(
             CompilationLevel compilationLevel,
             DependencyOptions.DependencyMode dependencyMode,
+            CompilerOptions.LanguageMode languageOut,
             @Nullable File jsSourceDir,
             List<File> jsZips,
             List<String> entrypoints,
@@ -66,7 +68,7 @@ public class Closure {
         jscompArgs.add(dependencyMode.name());
 
         jscompArgs.add("--language_out");
-        jscompArgs.add("ECMASCRIPT5");//TODO parameterize?
+        jscompArgs.add(languageOut.name());
 
         jscompArgs.addAll(Arrays.asList(//TODO parameterize?
                 "--jscomp_off",


### PR DESCRIPTION
Hi!

This pull request adds the ability to configure the output language, like this:

```xml
        <plugin>
          <groupId>com.vertispan.j2cl</groupId>
          <artifactId>j2cl-maven-plugin</artifactId>
          <version>${j2cl-plugin-version}</version>
          <configuration>
            <languageOut>ECMASCRIPT_2016</languageOut>
          </configuration>
        </plugin>
```

This is important if you are using newer web features, like web components. It does not change the default from ECMASCRIPT5, although that might be something to consider in a new issue.

I added a web components test in it/hello-world-web-components.

I bumped the version to 0.17-SNAPSHOT, lmk if I should change back to 0.16.