### PR TITLE
Enable sourcemaps by default in watch mode

### DIFF
--- a/src/main/java/net/cardosi/mojo/WatchMojo.java
+++ b/src/main/java/net/cardosi/mojo/WatchMojo.java
@@ -91,7 +91,7 @@ public class WatchMojo extends AbstractBuildMojo {
     @Parameter(defaultValue = "false")
     protected boolean rewritePolyfills;
 
-    @Parameter(defaultValue = "false")
+    @Parameter(defaultValue = "true")
     protected boolean enableSourcemaps;
 
     @Override


### PR DESCRIPTION
The sourcemap support is a killer feature of this plugin, lets enable them by default when running `j2cl:watch`.

Then instead of `mvn j2cl:watch -DenableSourcemaps=true` users can just `mvn j2cl:watch`.

This could cause compile time increases in certain cases, for massive project. However, I do not think this is a common case. Thus requiring them to explicitly disable sourcemaps makes sense.