### PR TITLE
bump directory-watcher version to 0.15.0

### DIFF
--- a/build-caching/pom.xml
+++ b/build-caching/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>io.methvin</groupId>
             <artifactId>directory-watcher</artifactId>
-            <version>0.14.0</version>
+            <version>0.15.0</version>
         </dependency>
 
         <!-- Test -->


### PR DESCRIPTION
This fix allows us to run j2cl-m-p on apple m1