### PR TITLE
Correctly use source_path to offer resources to annotation processors

### DIFF
--- a/j2cl-tools/src/main/java/com/vertispan/j2cl/build/provided/BytecodeTask.java
+++ b/j2cl-tools/src/main/java/com/vertispan/j2cl/build/provided/BytecodeTask.java
@@ -12,7 +12,6 @@ import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.util.Collection;
 import java.util.List;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -78,16 +77,14 @@ public class BytecodeTask extends TaskFactory {
                 return;// no work to do
             }
 
-            List<File> classpathDirs = Stream.of(
+            List<File> classpathDirs = Stream.concat(
                     bytecodeClasspath.stream().map(Input::getParentPaths).flatMap(Collection::stream).map(Path::toFile),
-                    extraClasspath.stream(),
-                    inputDirs.getParentPaths().stream().map(Path::toFile)
-            )
-                    .flatMap(Function.identity())
-                    .collect(Collectors.toList());
+                    extraClasspath.stream()
+            ).collect(Collectors.toList());
 
             // TODO don't dump APT to the same dir?
-            Javac javac = new Javac(output.path().toFile(), classpathDirs, output.path().toFile(), bootstrapClasspath);
+            List<File> sourcePaths = inputDirs.getParentPaths().stream().map(Path::toFile).collect(Collectors.toList());
+            Javac javac = new Javac(output.path().toFile(), sourcePaths, classpathDirs, output.path().toFile(), bootstrapClasspath);
 
             // TODO convention for mapping to original file paths, provide FileInfo out of Inputs instead of Paths,
             //      automatically relativized?

--- a/j2cl-tools/src/main/java/com/vertispan/j2cl/build/provided/JavacTask.java
+++ b/j2cl-tools/src/main/java/com/vertispan/j2cl/build/provided/JavacTask.java
@@ -57,7 +57,8 @@ public class JavacTask extends TaskFactory {
             List<File> classpathDirs = Stream.concat(classpathHeaders.stream().map(Input::getParentPaths).flatMap(Collection::stream).map(Path::toFile),
                     extraClasspath.stream()).collect(Collectors.toList());
 
-            Javac javac = new Javac(null, classpathDirs, output.path().toFile(), bootstrapClasspath);
+            List<File> sourcePaths = ownSources.getParentPaths().stream().map(Path::toFile).collect(Collectors.toList());
+            Javac javac = new Javac(null, sourcePaths, classpathDirs, output.path().toFile(), bootstrapClasspath);
 
             // TODO convention for mapping to original file paths, provide FileInfo out of Inputs instead of Paths,
             //      automatically relativized?

--- a/j2cl-tools/src/main/java/com/vertispan/j2cl/tools/Javac.java
+++ b/j2cl-tools/src/main/java/com/vertispan/j2cl/tools/Javac.java
@@ -29,7 +29,7 @@ public class Javac {
     JavaCompiler compiler;
     StandardJavaFileManager fileManager;
 
-    public Javac(File generatedClassesPath, List<File> classpath, File classesDirFile, File bootstrap) throws IOException {
+    public Javac(File generatedClassesPath, List<File> sourcePaths, List<File> classpath, File classesDirFile, File bootstrap) throws IOException {
 //        for (File file : classpath) {
 //            System.out.println(file.getAbsolutePath() + " " + file.exists() + " " + file.isDirectory());
 //        }
@@ -43,7 +43,7 @@ public class Javac {
         }
         compiler = ToolProvider.getSystemJavaCompiler();
         fileManager = compiler.getStandardFileManager(null, null, null);
-        fileManager.setLocation(StandardLocation.SOURCE_PATH, Collections.emptyList());
+        fileManager.setLocation(StandardLocation.SOURCE_PATH, sourcePaths);
         if (generatedClassesPath != null) {
             fileManager.setLocation(StandardLocation.SOURCE_OUTPUT, Collections.singleton(generatedClassesPath));
         }


### PR DESCRIPTION
This replaces commit 10c7ea5567 which added sources and resources
incorrectly to the classpath, preventing annotation processors from
being compiled, but it appeared to let them run correctly.

Fixes #87