### PR TITLE
Rebuild paths naively so that urls work

### DIFF
--- a/j2cl-maven-plugin/src/main/java/com/vertispan/j2cl/mojo/TestMojo.java
+++ b/j2cl-maven-plugin/src/main/java/com/vertispan/j2cl/mojo/TestMojo.java
@@ -48,6 +48,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.logging.Level;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @Mojo(name = "test", requiresDependencyResolution = ResolutionScope.TEST)
@@ -375,7 +376,8 @@ public class TestMojo extends AbstractBuildMojo {
                 int port = ((ServerConnector) server.getConnectors()[0]).getLocalPort();
 
                 try {
-                    String url = "http://localhost:" + port + "/" + startupHtmlFile.toString();
+                    String path = startupHtmlFile.toString().replaceAll(Pattern.quote(File.separator), "/");
+                    String url = "http://localhost:" + port + "/" + path;
                     getLog().info("fetching " + url);
                     driver.get(url);
 


### PR DESCRIPTION
This specifically fixes windows paths, so that /s appear in urls instead
of \s.