### PR TITLE
Ensure the watch goal can pick up the webapp dir

### DIFF
--- a/j2cl-maven-plugin/src/main/java/com/vertispan/j2cl/mojo/WatchMojo.java
+++ b/j2cl-maven-plugin/src/main/java/com/vertispan/j2cl/mojo/WatchMojo.java
@@ -201,7 +201,7 @@ public class WatchMojo extends AbstractBuildMojo {
                             child.setValue(initialScriptFilename);
                             watchGoalConfig.addChild(child);
                         }
-                        if (watchGoalConfig.getChild("webappDirectory") == null) {
+                        if (watchGoalConfig.getChild("webappDirectory") == null || watchGoalConfig.getChild("webappDirectory").getValue() == null) {
                             Xpp3Dom child = new Xpp3Dom("webappDirectory");
                             child.setValue(webappDirectory);
                             watchGoalConfig.addChild(child);


### PR DESCRIPTION
Previously this assumed the tag would be absent entirely, but it seems
that the tag can be present, without any value.