### PR TITLE
Ensure we don't consider directories when examining hash content

### DIFF
--- a/build-caching/src/main/java/com/vertispan/j2cl/build/DiskCache.java
+++ b/build-caching/src/main/java/com/vertispan/j2cl/build/DiskCache.java
@@ -237,6 +237,10 @@ public abstract class DiskCache {
 
                             @Override
                             public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                                if (attrs.isDirectory()) {
+                                    // ignore directories
+                                    return FileVisitResult.CONTINUE;
+                                }
                                 FileHash hash = PathUtils.hash(fileHasher, file);
                                 if (hash == null) {
                                     //file could have been deleted or was otherwise unreadable

--- a/build-caching/src/main/java/com/vertispan/j2cl/build/WatchService.java
+++ b/build-caching/src/main/java/com/vertispan/j2cl/build/WatchService.java
@@ -62,6 +62,7 @@ public class WatchService {
             Project project = entry.getValue();
             Path rootPath = entry.getKey();
             Map<Path, DiskCache.CacheEntry> projectFiles = directoryWatcher.pathHashes().entrySet().stream()
+                    .filter(e -> e.getValue() != FileHash.DIRECTORY)
                     .filter(e -> e.getKey().startsWith(rootPath))
                     .map(e -> new DiskCache.CacheEntry(rootPath.relativize(e.getKey()), rootPath, e.getValue()))
                     .collect(Collectors.toMap(e -> e.getSourcePath(), Function.identity()));


### PR DESCRIPTION
This fixes some issues when watching for changes in source directories.