### PR TITLE
BUNDLE_JAR must attempt to order JS files to satisfy dependencies

### DIFF
--- a/build-caching/src/main/java/com/vertispan/j2cl/build/Input.java
+++ b/build-caching/src/main/java/com/vertispan/j2cl/build/Input.java
@@ -67,6 +67,11 @@ public class Input implements com.vertispan.j2cl.build.task.Input {
         }
 
         @Override
+        public com.vertispan.j2cl.build.task.Project getProject() {
+            return wrapped.getProject();
+        }
+
+        @Override
         public String toString() {
             return "FilteredInput{" +
                     "wrapped=" + wrapped +
@@ -109,9 +114,7 @@ public class Input implements com.vertispan.j2cl.build.task.Input {
         }
     }
 
-    /**
-     * Internal API.
-     */
+    @Override
     public Project getProject() {
         return project;
     }

--- a/build-caching/src/main/java/com/vertispan/j2cl/build/task/Input.java
+++ b/build-caching/src/main/java/com/vertispan/j2cl/build/task/Input.java
@@ -1,12 +1,8 @@
 package com.vertispan.j2cl.build.task;
 
-import com.vertispan.j2cl.build.DiskCache;
-import io.methvin.watcher.hashing.FileHash;
-
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.util.Collection;
-import java.util.Map;
 
 public interface Input {
     /**
@@ -35,4 +31,9 @@ public interface Input {
      * directories of mapped projects, may result in zero to many items.
      */
     Collection<Path> getParentPaths();
+
+    /**
+     * Gets the project that this input comes from.
+     */
+    Project getProject();
 }

--- a/j2cl-maven-plugin/src/it/java-assertions/src/test/java/j2clsample/tests/MyTest.java
+++ b/j2cl-maven-plugin/src/it/java-assertions/src/test/java/j2clsample/tests/MyTest.java
@@ -10,6 +10,8 @@ import org.junit.Test;
  * that assertions are working in our various expected states. The pom should specify the assertion.armed
  * property so that this file knows whether or not to expect that the assertions are alive and will go
  * off if they fail.
+ *
+ * Note that this will fail in BUNDLE/BUNDLE_JAR mode since closure can't optimize out asserts.
  */
 @J2clTestInput(MyTest.class)
 public class MyTest {


### PR DESCRIPTION
This cannot always be successful, given a dependency graph with enough
conflicts (such as changing direction of dependencies between releases),
but this will at least try to satisfy that any dependency which will be
present at runtime is listed in the correct order, based on other
runtime dependencies.