### PR TITLE
Fix sourcemaps, improve closure logging

### DIFF
--- a/j2cl-tasks/src/main/java/com/vertispan/j2cl/build/provided/ClosureBundleTask.java
+++ b/j2cl-tasks/src/main/java/com/vertispan/j2cl/build/provided/ClosureBundleTask.java
@@ -38,7 +38,7 @@ public class ClosureBundleTask extends TaskFactory {
 
     @Override
     public String getVersion() {
-        return "0";
+        return "1";
     }
 
     @Override
@@ -73,7 +73,7 @@ public class ClosureBundleTask extends TaskFactory {
 
             // copy the sources locally so that we can create usable sourcemaps
             //TODO consider a soft link
-            File sources = new File(closureOutputDir, "sources");
+            File sources = new File(closureOutputDir, Closure.SOURCES_DIRECTORY_NAME);
             for (Path path : js.stream().map(Input::getParentPaths).flatMap(Collection::stream).collect(Collectors.toList())) {
                 FileUtils.copyDirectory(path.toFile(), sources);
             }
@@ -83,7 +83,15 @@ public class ClosureBundleTask extends TaskFactory {
                     CompilationLevel.BUNDLE,
                     DependencyOptions.DependencyMode.SORT_ONLY,
                     CompilerOptions.LanguageMode.NO_TRANSPILE,
-                    js,
+                    Collections.singletonMap(
+                            sources.getAbsolutePath(),
+                            js.stream()
+                                    .map(Input::getFilesAndHashes)
+                                    .flatMap(Collection::stream)
+                                    .map(CachedPath::getSourcePath)
+                                    .map(Path::toString)
+                                    .collect(Collectors.toList())
+                    ),
                     sources,
                     Collections.emptyList(),
                     Collections.emptyList(),

--- a/j2cl-tasks/src/main/java/com/vertispan/j2cl/build/provided/ClosureTask.java
+++ b/j2cl-tasks/src/main/java/com/vertispan/j2cl/build/provided/ClosureTask.java
@@ -118,7 +118,6 @@ public class ClosureTask extends TaskFactory {
                     js = Closure.mapFromInputs(jsSources);
                 }
                 if (sources != null) {
-//                    Files.createDirectories(Paths.get(closureOutputDir.getAbsolutePath(), initialScriptFilename).getParent());
                     for (Path path : jsSources.stream().map(Input::getParentPaths).flatMap(Collection::stream).collect(Collectors.toList())) {
                         FileUtils.copyDirectory(path.toFile(), sources);
                     }

--- a/j2cl-tasks/src/main/java/com/vertispan/j2cl/build/provided/JsZipBundleTask.java
+++ b/j2cl-tasks/src/main/java/com/vertispan/j2cl/build/provided/JsZipBundleTask.java
@@ -45,7 +45,7 @@ public class JsZipBundleTask extends TaskFactory {
                     CompilationLevel.BUNDLE,
                     DependencyOptions.DependencyMode.SORT_ONLY,
                     CompilerOptions.LanguageMode.NO_TRANSPILE,
-                    Collections.emptyList(),
+                    Collections.emptyMap(),
                     null,
                     extraJsZips,
                     Collections.emptyList(),


### PR DESCRIPTION
Sourcemaps again work consistently in BUNDLE, BUNDLE_JAR, and ADVANCED compilation levels.

Also avoids copying source content to output directories in some cases where it isn't required.