### PR TITLE
Create the parent directory of js output before calling closure

### DIFF
--- a/j2cl-maven-plugin/src/it/hello-world-single/invoker.properties
+++ b/j2cl-maven-plugin/src/it/hello-world-single/invoker.properties
@@ -1,0 +1,7 @@
+# As a very simple project, this is a good one to try each optimization level
+invoker.goals.1 = verify -DcompilationLevel=ADVANCED_OPTIMIZATIONS
+invoker.goals.2 = verify -DcompilationLevel=BUNDLE
+invoker.goals.3 = verify -DcompilationLevel=WHITESPACE_ONLY
+invoker.goals.4 = verify -DcompilationLevel=SIMPLE_OPTIMIZATIONS
+
+invoker.goals.5 = verify -DcompilationLevel=BUNDLE_JAR

--- a/j2cl-tasks/src/main/java/com/vertispan/j2cl/build/provided/ClosureTask.java
+++ b/j2cl-tasks/src/main/java/com/vertispan/j2cl/build/provided/ClosureTask.java
@@ -93,6 +93,7 @@ public class ClosureTask extends TaskFactory {
                 // set up a source directory to build from, and to make sourcemaps work
                 // TODO move logic to the "post" phase to decide whether or not to copy the sourcemap dir
                 String jsOutputDir = new File(closureOutputDir + "/" + initialScriptFilename).getParent();
+                Files.createDirectories(Paths.get(jsOutputDir));
                 final File sources;
                 final Map<String, List<String>> js;
                 if (!sourcemapsEnabled) {


### PR DESCRIPTION
This deals with an apparent bug in closure-compiler where BUNDLE output
is attempted to be created without creating the directory, though other
compilation levels handle that. The simple hello-world project was a
good candidate to test this, so now it smoke tests all compilation
levels.

Fixes #110