### PR TITLE
Treat pom scope=runtime as compile to make gradle poms usable

### DIFF
--- a/j2cl-maven-plugin/src/main/java/com/vertispan/j2cl/mojo/AbstractBuildMojo.java
+++ b/j2cl-maven-plugin/src/main/java/com/vertispan/j2cl/mojo/AbstractBuildMojo.java
@@ -307,7 +307,7 @@ public abstract class AbstractBuildMojo extends AbstractCacheMojo {
             case Artifact.SCOPE_PROVIDED:
                 return Dependency.Scope.COMPILE;
             case Artifact.SCOPE_RUNTIME:
-                return Dependency.Scope.RUNTIME;
+                return Dependency.Scope.BOTH;
             // These two should already be removed by earlier filtering, throw anyway
             case Artifact.SCOPE_IMPORT:
             case Artifact.SCOPE_SYSTEM:


### PR DESCRIPTION
Gradle's "implementation" configuration for dependencies results in
published maven poms that are technically accurate for building
bytecode, but useless for building J2CL. To fix this, we interpret any
scope=runtime as if it says scope=compile.

A separate commit will include a test case to verify that the published
gwt modules in maven central work properly.

Fixes #126