### PR TITLE
Update to latest closure v20220502-1

### DIFF
--- a/j2cl-tasks/src/main/java/com/vertispan/j2cl/build/provided/ClosureBundleTask.java
+++ b/j2cl-tasks/src/main/java/com/vertispan/j2cl/build/provided/ClosureBundleTask.java
@@ -98,7 +98,6 @@ public class ClosureBundleTask extends TaskFactory {
                     Collections.emptyMap(),
                     Collections.emptyList(),//TODO actually pass these in when we can restrict and cache them sanely
                     Optional.empty(),
-                    null,
                     true,//TODO have this be passed in,
                     true,//default to true, will have no effect anyway
                     false,

--- a/j2cl-tasks/src/main/java/com/vertispan/j2cl/build/provided/ClosureTask.java
+++ b/j2cl-tasks/src/main/java/com/vertispan/j2cl/build/provided/ClosureTask.java
@@ -234,7 +234,6 @@ public class ClosureTask extends TaskFactory {
                         defines,
                         externs,
                         translationsfile,
-                        null,
                         true,//TODO have this be passed in,
                         checkAssertions,
                         rewritePolyfills,

--- a/j2cl-tasks/src/main/java/com/vertispan/j2cl/build/provided/JsZipBundleTask.java
+++ b/j2cl-tasks/src/main/java/com/vertispan/j2cl/build/provided/JsZipBundleTask.java
@@ -56,7 +56,6 @@ public class JsZipBundleTask extends TaskFactory {
                     Collections.emptyMap(),
                     Collections.emptyList(),
                     Optional.empty(),
-                    null,
                     true,
                     true,
                     false,

--- a/j2cl-tasks/src/main/java/com/vertispan/j2cl/tools/Closure.java
+++ b/j2cl-tasks/src/main/java/com/vertispan/j2cl/tools/Closure.java
@@ -55,7 +55,6 @@ public class Closure {
             Map<String, String> defines,
             Collection<String> externFiles,
             Optional<File> translationsFile,
-            PersistentInputStore persistentInputStore,
             boolean exportTestFunctions,
             boolean checkAssertions,
             boolean rewritePolyfills,
@@ -66,7 +65,6 @@ public class Closure {
         List<String> jscompArgs = new ArrayList<>();
 
         Compiler jsCompiler = new Compiler(System.err);
-//        jsCompiler.setPersistentInputStore(persistentInputStore);
 
         // List the parent directories of each input so that module resolution works as expected
         jsInputs.keySet().forEach(parentPath -> {
@@ -187,21 +185,12 @@ public class Closure {
             return false;
         }
 
-        //TODO historically we didnt populate the persistent input store until this point, so put it here
-        //     if we restore it
+        jscompRunner.run();
 
-        try {
-            jscompRunner.run();
-
-            if (jscompRunner.hasErrors() || jscompRunner.exitCode != 0) {
-                return false;
-            }
-        } finally {
-            if (jsCompiler.getModules() != null) {
-                // clear out the compiler input for the next go-around
-                jsCompiler.resetCompilerInput();
-            }
+        if (jscompRunner.hasErrors() || jscompRunner.exitCode != 0) {
+            return false;
         }
+
         return true;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
 
     <!-- Builder dependencies versions -->
     <j2cl.version>0.10.0-3c97afeac</j2cl.version>
-    <closure.compiler.unshaded.version>v20210808-1</closure.compiler.unshaded.version>
+    <closure.compiler.unshaded.version>v20220502-1</closure.compiler.unshaded.version>
     <commons.codec.version>1.11</commons.codec.version>
     <commons.io.version>2.7</commons.io.version>
 
@@ -101,7 +101,7 @@
     <plexus.utils.version>3.1.0</plexus.utils.version>
     <plexus.classworlds.version>2.5.2</plexus.classworlds.version>
     <plexus.interpolation.version>1.25</plexus.interpolation.version>
-    <guava.version>30.0-jre</guava.version>
+    <guava.version>31.1-jre</guava.version>
     <error.prone.annotations.version>2.1.3</error.prone.annotations.version>
     <jsr305.version>3.0.2</jsr305.version>
     <commons.lang3.version>3.8.1</commons.lang3.version>
@@ -194,29 +194,30 @@
       </dependency>
 
       <dependency>
-        <groupId>com.vertispan.javascript</groupId>
-        <artifactId>closure-compiler-unshaded</artifactId>
-        <version>${closure.compiler.unshaded.version}</version>
+        <groupId>com.vertispan.j2cl</groupId>
+        <artifactId>backend-libraryinfo</artifactId>
+        <version>${j2cl.version}</version>
         <exclusions>
-          <exclusion>
-            <groupId>com.google.jsinterop</groupId>
-            <artifactId>jsinterop-annotations</artifactId>
-          </exclusion>
           <exclusion>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>args4j</groupId>
-            <artifactId>args4j</artifactId>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java-util</artifactId>
           </exclusion>
+        </exclusions>
+      </dependency>
+
+
+      <dependency>
+        <groupId>com.vertispan.javascript</groupId>
+        <artifactId>closure-compiler-unshaded</artifactId>
+        <version>${closure.compiler.unshaded.version}</version>
+        <exclusions>
           <exclusion>
-            <groupId>com.google.jsinterop</groupId>
-            <artifactId>base</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.google.elemental2</groupId>
-            <artifactId>*</artifactId>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
This is the end of persistent input store, which was never used in this
iteration of j2cl-m-p. Instead, we'll be moving towards the typedast
feature, which closure-compiler uses to break its build into "stages".

This also fixes #157, by adding a new commit to our closure-compiler
feature of allowing sourcemaps in BUNDLE mode - contents loaded from a
different fs root will not try to relativize any longer.