### PR TITLE
ignore-maven-apt-test-annotations

### DIFF
--- a/j2cl-maven-plugin/src/it/annotation-processor-in-reactor/app/src/test/java/com/example/MyTestResources.java
+++ b/j2cl-maven-plugin/src/it/annotation-processor-in-reactor/app/src/test/java/com/example/MyTestResources.java
@@ -1,0 +1,10 @@
+package com.example;
+
+@MyAnnotation
+public interface MyTestResources {
+    public static final MyTestResources INSTANCE = new MyTestResources_Impl();
+
+    @MyAnnotation("test-res-in-root-dir.txt")
+    String testResourceInRoot();
+
+}

--- a/j2cl-maven-plugin/src/it/annotation-processor-in-reactor/app/src/test/java/com/example/ResourceTest.java
+++ b/j2cl-maven-plugin/src/it/annotation-processor-in-reactor/app/src/test/java/com/example/ResourceTest.java
@@ -16,5 +16,8 @@ public class ResourceTest {
         Assert.assertEquals("res-in-package.txt", res.resourceInPackage());
         Assert.assertEquals("res-in-java-default-package.txt", res.resourceInJavaSourceRoot());
         Assert.assertEquals("res-in-java-nested-package.txt", res.resourceInJavaPackage());
+
+        MyTestResources testRes = MyTestResources.INSTANCE;
+        Assert.assertEquals("test-res-in-root-dir.txt", testRes.testResourceInRoot());
     }
 }

--- a/j2cl-maven-plugin/src/it/annotation-processor-in-reactor/resources/src/main/resources/test-res-in-root-dir.txt
+++ b/j2cl-maven-plugin/src/it/annotation-processor-in-reactor/resources/src/main/resources/test-res-in-root-dir.txt
@@ -1,0 +1,1 @@
+test-res-in-root-dir.txt

--- a/j2cl-maven-plugin/src/main/java/com/vertispan/j2cl/mojo/AbstractBuildMojo.java
+++ b/j2cl-maven-plugin/src/main/java/com/vertispan/j2cl/mojo/AbstractBuildMojo.java
@@ -283,9 +283,7 @@ public abstract class AbstractBuildMojo extends AbstractCacheMojo {
                             mavenProject.getResources().stream().map(FileSet::getDirectory)
                     )
                             .distinct()
-                            .filter(path -> new File(path).exists())
-                            .filter(path -> !(annotationProcessorMode.pluginShouldExcludeGeneratedAnnotationsDir()
-                                    && path.endsWith("generated-sources" + File.separator + "annotations")))
+                            .filter(withSourceRootFilter())
                             .collect(Collectors.toList())
             );
         } else {
@@ -325,10 +323,11 @@ public abstract class AbstractBuildMojo extends AbstractCacheMojo {
         return new TaskRegistry(taskMappings);
     }
 
-    protected Predicate<String> withTestSourcePathFilter() {
-        return path ->
+    protected Predicate<String> withSourceRootFilter() {
+        return path -> new File(path).exists() &&
             !(annotationProcessorMode.pluginShouldExcludeGeneratedAnnotationsDir()
-                && path.endsWith("generated-test-sources" + File.separator + "test-annotations"));
+                && (path.endsWith("generated-test-sources" + File.separator + "test-annotations") || 
+                    path.endsWith("generated-sources" + File.separator + "annotations")));
     }
 
 }

--- a/j2cl-maven-plugin/src/main/java/com/vertispan/j2cl/mojo/AbstractBuildMojo.java
+++ b/j2cl-maven-plugin/src/main/java/com/vertispan/j2cl/mojo/AbstractBuildMojo.java
@@ -76,7 +76,7 @@ public abstract class AbstractBuildMojo extends AbstractCacheMojo {
     protected List<DependencyReplacement> dependencyReplacements;
 
     @Parameter(defaultValue = "AVOID_MAVEN")
-    private AnnotationProcessorMode annotationProcessorMode;
+    protected AnnotationProcessorMode annotationProcessorMode;
 
     private List<DependencyReplacement> defaultDependencyReplacements = Arrays.asList(
             new DependencyReplacement("com.google.jsinterop:base", "com.vertispan.jsinterop:base:" + Versions.VERTISPAN_JSINTEROP_BASE_VERSION),

--- a/j2cl-maven-plugin/src/main/java/com/vertispan/j2cl/mojo/AbstractBuildMojo.java
+++ b/j2cl-maven-plugin/src/main/java/com/vertispan/j2cl/mojo/AbstractBuildMojo.java
@@ -29,6 +29,7 @@ import org.eclipse.aether.resolution.ArtifactResolutionException;
 
 import java.io.File;
 import java.util.*;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -76,7 +77,7 @@ public abstract class AbstractBuildMojo extends AbstractCacheMojo {
     protected List<DependencyReplacement> dependencyReplacements;
 
     @Parameter(defaultValue = "AVOID_MAVEN")
-    protected AnnotationProcessorMode annotationProcessorMode;
+    private AnnotationProcessorMode annotationProcessorMode;
 
     private List<DependencyReplacement> defaultDependencyReplacements = Arrays.asList(
             new DependencyReplacement("com.google.jsinterop:base", "com.vertispan.jsinterop:base:" + Versions.VERTISPAN_JSINTEROP_BASE_VERSION),
@@ -323,4 +324,11 @@ public abstract class AbstractBuildMojo extends AbstractCacheMojo {
         // use any task wiring if specified
         return new TaskRegistry(taskMappings);
     }
+
+    protected Predicate<String> withTestSourcePathFilter() {
+        return path ->
+            !(annotationProcessorMode.pluginShouldExcludeGeneratedAnnotationsDir()
+                && path.endsWith("generated-test-sources" + File.separator + "test-annotations"));
+    }
+
 }

--- a/j2cl-maven-plugin/src/main/java/com/vertispan/j2cl/mojo/TestMojo.java
+++ b/j2cl-maven-plugin/src/main/java/com/vertispan/j2cl/mojo/TestMojo.java
@@ -312,7 +312,7 @@ public class TestMojo extends AbstractBuildMojo {
             mainDep.setProject(main);
             testDeps.add(mainDep);
             test.setDependencies(testDeps);
-            test.setSourceRoots(project.getTestCompileSourceRoots().stream().filter(withTestSourcePathFilter()).collect(Collectors.toList()));
+            test.setSourceRoots(project.getTestCompileSourceRoots().stream().filter(withSourceRootFilter()).collect(Collectors.toList()));
             test.getSourceRoots().addAll(project.getTestResources().stream().map(FileSet::getDirectory).collect(Collectors.toList()));
         } catch (ProjectBuildingException e) {
             throw new MojoExecutionException("Failed to build project structure", e);

--- a/j2cl-maven-plugin/src/main/java/com/vertispan/j2cl/mojo/TestMojo.java
+++ b/j2cl-maven-plugin/src/main/java/com/vertispan/j2cl/mojo/TestMojo.java
@@ -312,12 +312,7 @@ public class TestMojo extends AbstractBuildMojo {
             mainDep.setProject(main);
             testDeps.add(mainDep);
             test.setDependencies(testDeps);
-            test.setSourceRoots(project.getTestCompileSourceRoots().stream().filter(
-                  path -> 
-                        !(annotationProcessorMode.pluginShouldExcludeGeneratedAnnotationsDir()
-                            && path.endsWith(
-                                "generated-test-sources" + File.separator + "test-annotations")))
-                .collect(Collectors.toList()));
+            test.setSourceRoots(project.getTestCompileSourceRoots().stream().filter(withTestSourcePathFilter()).collect(Collectors.toList()));
             test.getSourceRoots().addAll(project.getTestResources().stream().map(FileSet::getDirectory).collect(Collectors.toList()));
         } catch (ProjectBuildingException e) {
             throw new MojoExecutionException("Failed to build project structure", e);

--- a/j2cl-maven-plugin/src/main/java/com/vertispan/j2cl/mojo/TestMojo.java
+++ b/j2cl-maven-plugin/src/main/java/com/vertispan/j2cl/mojo/TestMojo.java
@@ -312,7 +312,12 @@ public class TestMojo extends AbstractBuildMojo {
             mainDep.setProject(main);
             testDeps.add(mainDep);
             test.setDependencies(testDeps);
-            test.setSourceRoots(new ArrayList<>(project.getTestCompileSourceRoots()));
+            test.setSourceRoots(project.getTestCompileSourceRoots().stream().filter(
+                  path -> 
+                        !(annotationProcessorMode.pluginShouldExcludeGeneratedAnnotationsDir()
+                            && path.endsWith(
+                                "generated-test-sources" + File.separator + "test-annotations")))
+                .collect(Collectors.toList()));
             test.getSourceRoots().addAll(project.getTestResources().stream().map(FileSet::getDirectory).collect(Collectors.toList()));
         } catch (ProjectBuildingException e) {
             throw new MojoExecutionException("Failed to build project structure", e);


### PR DESCRIPTION
Fix to ignore maven apt generated files with scope test (directory generated-test-sources/test-annotations)