### PR TITLE
When a task is ready to run and enqueued, mark it as started right away

### DIFF
--- a/build-caching/src/main/java/com/vertispan/j2cl/build/DiskCache.java
+++ b/build-caching/src/main/java/com/vertispan/j2cl/build/DiskCache.java
@@ -55,12 +55,12 @@ public abstract class DiskCache {
         }
 
         public void markSuccess() {
-            runningTasks.remove(taskDir);
             markFinished(this);
+            runningTasks.remove(taskDir);
         }
         public void markFailure() {
-            runningTasks.remove(taskDir);
             markFailed(this);
+            runningTasks.remove(taskDir);
         }
 
         public void markBegun() {

--- a/build-caching/src/main/java/com/vertispan/j2cl/build/TaskScheduler.java
+++ b/build-caching/src/main/java/com/vertispan/j2cl/build/TaskScheduler.java
@@ -211,7 +211,6 @@ public class TaskScheduler {
                     }
                     try {
                         long start = System.currentTimeMillis();
-                        result.markBegun();
                         taskDetails.getTask().execute(new TaskContext(result.outputDir(), log));
                         if (Thread.currentThread().isInterrupted()) {
                             // Tried and failed to be canceled, so even though we were successful, some files might
@@ -262,6 +261,7 @@ public class TaskScheduler {
                 public void onReady(DiskCache.CacheResult cacheResult) {
                     // We can now begin this work off-thread, will be woken up when it finishes.
                     // It is too late to cancel at this time, so no need to check.
+                    cacheResult.markBegun();
                     executor.execute(() -> {
                         executeTask(taskDetails, cacheResult, listener);
                     });


### PR DESCRIPTION
This solves a bug where a task might be enqueued in the executor service
for longer than the stale timeout, so the cache believes that the
running task is in fact stale/canceled, and attempts to cancel it, but
this races against the task actually starting and trying to use the
files it expected to have access to.

Fixes #186