### PR TITLE
In watch mode, changed, created and deleted files are now processed a…

### DIFF
--- a/build-caching/pom.xml
+++ b/build-caching/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>io.methvin</groupId>
             <artifactId>directory-watcher</artifactId>
-            <version>0.15.0</version>
+            <version>0.16.1</version>
         </dependency>
 
         <!-- Test -->


### PR DESCRIPTION
…s a bulk set,  based on timeout value

Latest directory-watcher adds ability to set timeout, in which changes are accumulated in one change set. 

It's very useful in large projects where IDE permanently saves files which leads to permanent recompilation.

Maybe it could be a good idea to make timeout value (now it's 500ms) configurable.