### PR TITLE
Correct externs so the compiler avoids a warning

### DIFF
--- a/j2cl-maven-plugin/src/it/top-level-source-file/src/main/java/externs.js
+++ b/j2cl-maven-plugin/src/it/top-level-source-file/src/main/java/externs.js
@@ -1,10 +1,10 @@
 // As this file is at the top level of the main java dir, it won't match a **/*.js glob
 
-/*
+/**
  * @externs
  */
 
-/*
+/**
  * @constructor
  */
 function Foo() {}


### PR DESCRIPTION
In theory we should have gotten an error for this instead of a warning, but at least the tests confirmed that the file could be loaded at all.