### PR TITLE
Fix a path in the (disabled) web component integration test

### DIFF
--- a/j2cl-maven-plugin/src/it/hello-world-web-components/src/main/webapp/index.html
+++ b/j2cl-maven-plugin/src/it/hello-world-web-components/src/main/webapp/index.html
@@ -8,7 +8,7 @@
     <p>Hello World, Web Components</p>
   </template>
 
-  <script type="application/javascript" src="hello-world-web-components/hello-world-web-components.js"></script>
+  <script type="application/javascript" src="hello-world-custom-elements/hello-world-custom-elements.js"></script>
 </head>
 <body>
 <hello-world></hello-world>


### PR DESCRIPTION
With this path corrected, the test can again be manually confirmed.