### PR TITLE
Drop support for Java 8, in anticipation of updating closure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,17 +35,13 @@ jobs:
 
     strategy:
       matrix:
-        mvn: ['3.8.5', '3.6.3', '3.5.4', '3.3.9', '3.2.5']
+        mvn: ['3.8.6', '3.6.3', '3.5.4', '3.3.9', '3.2.5']
         java: ['11']
-        include: # Confirm that old java works in the oldest maven, and that newest maven supports 8-current
-          - mvn: '3.2.5'
-            java: '8'
-          - mvn: '3.8.5'
-            java: '8'
-            #TODO j2clmavenplugin#159 - re-enable this when the integration tests run cleanly in Java 17+
-#          - mvn: '3.8.5'
+#        include: # Confirm that old java works in the oldest maven, and that newest maven supports 8-current
+#            #TODO j2clmavenplugin#159 - re-enable this when the integration tests run cleanly in Java 17+
+#          - mvn: '3.8.6'
 #            java: '17'
-#          - mvn: '3.8.5'
+#          - mvn: '3.8.6'
 #            java: '18'
     steps:
       - name: Checkout

--- a/pom.xml
+++ b/pom.xml
@@ -340,6 +340,9 @@
             <configuration>
               <rules>
                 <dependencyConvergence/>
+                <requireJavaVersion>
+                  <version>[11,)</version>
+                </requireJavaVersion>
               </rules>
             </configuration>
             <goals>


### PR DESCRIPTION
Builds will seem to work correctly until turbine or closure runs, as this commit doesn't actually change the language or bytecode level yet.

We should go a step further for the mojos and actually give a human readable error, if there is no way to otherwise have maven validate that the plugin requires Java 8.