### PR TITLE
Update circleci to a newer image format with Java 11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
     working_directory: ~/repo
     docker:
-      - image: circleci/openjdk:8-jdk-stretch
+      - image: cimg/openjdk:11.0
     filters:
       branches:
         only:


### PR DESCRIPTION
Likely this should be replaced with github actions, but for now this keeps snapshots working.