### PR TITLE
Update J2CL and Closure dependencies

### DIFF
--- a/j2cl-tasks/src/main/java/com/vertispan/j2cl/build/provided/BundleJarTask.java
+++ b/j2cl-tasks/src/main/java/com/vertispan/j2cl/build/provided/BundleJarTask.java
@@ -3,6 +3,7 @@ package com.vertispan.j2cl.build.provided;
 import com.google.auto.service.AutoService;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.javascript.jscomp.deps.ClosureBundler;
 import com.vertispan.j2cl.build.task.*;
 import com.vertispan.j2cl.tools.Closure;
 import org.apache.commons.io.FileUtils;
@@ -145,11 +146,17 @@ public class BundleJarTask extends TaskFactory {
                             "  elt.async = false;\n" +
                             "  document.head.appendChild(elt);\n" +
                             "});" + "})();";
+
+                    // Closure bundler runtime
+                    StringBuilder runtime = new StringBuilder();
+                    new ClosureBundler().appendRuntimeTo(runtime);
+
                     Files.write(initialScriptFile.toPath(), Arrays.asList(
                             defineLine,
                             intro,
                             scriptsArray,
-                            outro
+                            outro,
+                            runtime
                     ));
                 } catch (IOException e) {
                     throw new UncheckedIOException("Failed to write html import file", e);

--- a/j2cl-tasks/src/main/java/com/vertispan/j2cl/tools/Closure.java
+++ b/j2cl-tasks/src/main/java/com/vertispan/j2cl/tools/Closure.java
@@ -153,6 +153,13 @@ public class Closure {
             jscompArgs.add("IIFE");
         }
 
+        if (compilationLevel == CompilationLevel.BUNDLE) {
+            // avoid injecting libraries, the runtime will be added as part of the BundleJarTask step in the
+            // initial download
+            jscompArgs.add("--inject_libraries");
+            jscompArgs.add("false");
+        }
+
         for (String entrypoint : entrypoints) {
             jscompArgs.add("--entry_point");
             jscompArgs.add(entrypoint);

--- a/j2cl-tasks/src/main/java/com/vertispan/j2cl/tools/J2cl.java
+++ b/j2cl-tasks/src/main/java/com/vertispan/j2cl/tools/J2cl.java
@@ -1,5 +1,6 @@
 package com.vertispan.j2cl.tools;
 
+import com.google.common.collect.ImmutableList;
 import com.google.j2cl.common.OutputUtils;
 import com.google.j2cl.common.SourceUtils;
 import com.google.j2cl.common.Problems;
@@ -11,6 +12,7 @@ import com.vertispan.j2cl.build.task.BuildLog;
 
 import javax.annotation.Nonnull;
 import java.io.File;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -44,6 +46,8 @@ public class J2cl {
                     .setOutput(output)
                     .setSources(sourcesToCompile)
                     .setNativeSources(nativeSources)
+                    .setKotlinCommonSources(Collections.emptyList())
+                    .setKotlincOptions(ImmutableList.of())
                     .build();
 
             log.debug(options.toString());

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
 
     <!-- Builder dependencies versions -->
     <j2cl.version>0.11-SNAPSHOT</j2cl.version>
-    <closure.compiler.unshaded.version>HEAD-SNAPSHOT</closure.compiler.unshaded.version>
+    <closure.compiler.unshaded.version>v20221102-1</closure.compiler.unshaded.version>
     <commons.codec.version>1.11</commons.codec.version>
     <commons.io.version>2.7</commons.io.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -87,8 +87,8 @@
     <maven.gpg.plugin.version>1.6</maven.gpg.plugin.version>
 
     <!-- Builder dependencies versions -->
-    <j2cl.version>0.10.0-3c97afeac</j2cl.version>
-    <closure.compiler.unshaded.version>v20220502-1</closure.compiler.unshaded.version>
+    <j2cl.version>0.11-SNAPSHOT</j2cl.version>
+    <closure.compiler.unshaded.version>HEAD-SNAPSHOT</closure.compiler.unshaded.version>
     <commons.codec.version>1.11</commons.codec.version>
     <commons.io.version>2.7</commons.io.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <maven.gpg.plugin.version>1.6</maven.gpg.plugin.version>
 
     <!-- Builder dependencies versions -->
-    <j2cl.version>0.11-SNAPSHOT</j2cl.version>
+    <j2cl.version>0.11.0-9336533b6</j2cl.version>
     <closure.compiler.unshaded.version>v20221102-1</closure.compiler.unshaded.version>
     <commons.codec.version>1.11</commons.codec.version>
     <commons.io.version>2.7</commons.io.version>


### PR DESCRIPTION
This branch brings us up to Nov 2022 for closure-compiler, Aug 2022 for J2CL, but leaves our current closure-library dependency at Aug 2021 for now.

The closure-compiler fork includes changes for BUNDLE to avoid parsing JS files, but only scan for dependencies or ES6 modules that require transpilation in order to be bundled.

Updating closure-compiler adds a hard dependency on Java 11+, but we've already officially dropped support for Java 8 in this repository.