### PR TITLE
Add integration test for generated code in reactor (JavaCC)

### DIFF
--- a/j2cl-maven-plugin/src/it/annotation-processor-in-reactor/app/src/main/java/com/example/MyApp.java
+++ b/j2cl-maven-plugin/src/it/annotation-processor-in-reactor/app/src/main/java/com/example/MyApp.java
@@ -3,5 +3,10 @@ package com.example;
 public class MyApp {
     public static void start() {
         MyResources.INSTANCE.resourceInRoot();
+        try {
+            BasicParser.parse("{{}}");
+        } catch(Exception ex) {
+            // parse exception ignored
+        }
     }
 }

--- a/j2cl-maven-plugin/src/it/annotation-processor-in-reactor/resources/pom.xml
+++ b/j2cl-maven-plugin/src/it/annotation-processor-in-reactor/resources/pom.xml
@@ -19,5 +19,22 @@
                 <directory>src/main/java</directory>
             </resource>
         </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>javacc-maven-plugin</artifactId>
+                <version>3.0.1</version>
+                <configuration>
+                    <jdkVersion>1.8</jdkVersion>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>javacc</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 </project>

--- a/j2cl-maven-plugin/src/it/annotation-processor-in-reactor/resources/src/main/javacc/com/example/BasicParser.jj
+++ b/j2cl-maven-plugin/src/it/annotation-processor-in-reactor/resources/src/main/javacc/com/example/BasicParser.jj
@@ -1,0 +1,36 @@
+options {
+  LOOKAHEAD = 1;
+  CHOICE_AMBIGUITY_CHECK = 2;
+  OTHER_AMBIGUITY_CHECK = 1;
+  STATIC = true;
+  DEBUG_PARSER = false;
+  DEBUG_LOOKAHEAD = false;
+  JAVA_TEMPLATE_TYPE = "modern";
+}
+
+PARSER_BEGIN(BasicParser)
+
+package com.example;
+
+public class BasicParser {
+
+  public static void parse(String content) throws ParseException {
+    BasicParser parser = new BasicParser(content);
+    parser.Input();
+  }
+
+}
+
+PARSER_END(BasicParser)
+
+void Input() :
+{}
+{
+  MatchedBraces() ("\n"|"\r")* <EOF>
+}
+
+void MatchedBraces() :
+{}
+{
+  "{" [ MatchedBraces() ] "}"
+}


### PR DESCRIPTION
This integration test fails locally with
```
[ERROR] annotation-processor-in-reactor:app:1.0/bytecode: /C:/Users/zbynek/git/j2clmavenplugin/j2cl-maven-plugin/target/it-tests/annotation-processor-in-reactor/app/src/main/java/com/example/MyApp.java:7 cannot find symbol
  symbol:   variable BasicParser
  location: class com.example.MyApp
java.lang.RuntimeException: Failed to complete bytecode task, check log
	at com.vertispan.j2cl.build.provided.BytecodeTask.lambda$resolve$3(BytecodeTask.java:100)
	at com.vertispan.j2cl.build.TaskScheduler$2.executeTask(TaskScheduler.java:214)
	at com.vertispan.j2cl.build.TaskScheduler$2.lambda$onReady$0(TaskScheduler.java:266)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
[ERROR] Exception executing task annotation-processor-in-reactor:app:1.0/bytecode
java.lang.RuntimeException: Failed to complete bytecode task, check log
    at com.vertispan.j2cl.build.provided.BytecodeTask.lambda$resolve$3 (BytecodeTask.java:100)
    at com.vertispan.j2cl.build.TaskScheduler$2.executeTask (TaskScheduler.java:214)
    at com.vertispan.j2cl.build.TaskScheduler$2.lambda$onReady$0 (TaskScheduler.java:266)
    at java.util.concurrent.Executors$RunnableAdapter.call (Executors.java:515)
    at java.util.concurrent.FutureTask.run (FutureTask.java:264)
    at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run (ScheduledThreadPoolExecutor.java:304)
    at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1128)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:628)
    at java.lang.Thread.run (Thread.java:829)
java.lang.RuntimeException
	at com.vertispan.j2cl.build.DiskCache.markFailed(DiskCache.java:542)
	at com.vertispan.j2cl.build.DiskCache$CacheResult.markFailure(DiskCache.java:62)
	at com.vertispan.j2cl.build.TaskScheduler$2.executeTask(TaskScheduler.java:235)
	at com.vertispan.j2cl.build.TaskScheduler$2.lambda$onReady$0(TaskScheduler.java:266)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```
If it's my fault please let me know how to fix it, otherwise please check if this can be supported by the J2CL plugin.