### PR TITLE
Fix version number of archetypes in documentation

### DIFF
--- a/j2cl-archetypes/README.md
+++ b/j2cl-archetypes/README.md
@@ -7,14 +7,14 @@ To create a project interactively, use:
 ```
 mvn archetype:generate -DarchetypeGroupId=com.vertispan.j2cl.archetypes \
 -DarchetypeArtifactId=<archetype-name> \
--DarchetypeVersion=0.21
+-DarchetypeVersion=0.21.0
 ```
 
 To specify these four variables, add them as system properties:
 ```
 mvn archetype:generate -DarchetypeGroupId=com.vertispan.j2cl.archetypes \
 -DarchetypeArtifactId=<archetype-name> \
--DarchetypeVersion=0.21 \
+-DarchetypeVersion=0.21.0 \
 -DgroupId=my.project.group.id \
 -DartifactId=myapp \
 -Dversion=1.0-SNAPSHOT \
@@ -26,7 +26,7 @@ to replace `<archetype-name>` with the name of the archetype:
 ```
 mvn org.apache.maven.plugins:maven-dependency-plugin:get \
 -DrepoUrl=https://repo.vertispan.com/j2cl/ \
--Dartifact=com.vertispan.j2cl.archetypes:<archetype-name>:0.21
+-Dartifact=com.vertispan.j2cl.archetypes:<archetype-name>:0.21.0
 ```
 
 # [`j2cl-archetype-simple`](j2cl-archetype-simple)


### PR DESCRIPTION
While trying to run the archetypes, I found that the documentation used the wrong version numbers. 