### PR TITLE
Update dependencies from Google repos

### DIFF
--- a/j2cl-maven-plugin/src/it/elemental2-project/pom.xml
+++ b/j2cl-maven-plugin/src/it/elemental2-project/pom.xml
@@ -7,7 +7,7 @@
     <version>1.0</version>
 
     <properties>
-        <elemental2.version>1.1.0</elemental2.version>
+        <elemental2.version>1.2.1</elemental2.version>
     </properties>
 
     <dependencies>

--- a/j2cl-tasks/src/main/java/com/vertispan/j2cl/build/provided/ClosureBundleTask.java
+++ b/j2cl-tasks/src/main/java/com/vertispan/j2cl/build/provided/ClosureBundleTask.java
@@ -241,7 +241,7 @@ public class ClosureBundleTask extends TaskFactory {
     public interface SourceSupplier {
         String get() throws IOException;
     }
-    public static class DependencyInfoAndSource extends DependencyInfo.Base {
+    public static class DependencyInfoAndSource implements DependencyInfo {
         private final DependencyInfo delegate;
         private final SourceSupplier sourceSupplier;
 
@@ -291,11 +291,6 @@ public class ClosureBundleTask extends TaskFactory {
         }
 
         @Override
-        public boolean isModule() {
-            return delegate.isModule();
-        }
-
-        @Override
         public boolean isEs6Module() {
             return delegate.isEs6Module();
         }
@@ -316,7 +311,7 @@ public class ClosureBundleTask extends TaskFactory {
         }
     }
 
-    public static class DependencyInfoFormat extends DependencyInfo.Base {
+    public static class DependencyInfoFormat implements DependencyInfo {
         private String name;
 //        private String pathRelativeToClosureBase = name;
         private List<String> provides;

--- a/j2cl-tasks/src/main/java/com/vertispan/j2cl/tools/GwtIncompatiblePreprocessor.java
+++ b/j2cl-tasks/src/main/java/com/vertispan/j2cl/tools/GwtIncompatiblePreprocessor.java
@@ -29,7 +29,7 @@ public class GwtIncompatiblePreprocessor {
         Problems problems = new Problems();
 
         try (OutputUtils.Output output = OutputUtils.initOutput(outputDirectory.toPath(), problems)) {
-            GwtIncompatibleStripper.preprocessFiles(unprocessedFiles, output, problems);
+            GwtIncompatibleStripper.preprocessFiles(unprocessedFiles, output, problems, "GwtIncompatible");
 
             if (problems.hasErrors()) {
                 throw new IllegalStateException(problems.getErrors().toString());

--- a/j2cl-tasks/src/main/java/com/vertispan/j2cl/tools/J2cl.java
+++ b/j2cl-tasks/src/main/java/com/vertispan/j2cl/tools/J2cl.java
@@ -46,9 +46,9 @@ public class J2cl {
                     .setOutput(output)
                     .setSources(sourcesToCompile)
                     .setNativeSources(nativeSources)
-                    .setKotlinCommonSources(Collections.emptyList())
                     .setKotlincOptions(ImmutableList.of())
-                    .build();
+                    .setWasmEntryPointStrings(ImmutableList.of())
+                    .build(problems);
 
             log.debug(options.toString());
 

--- a/pom.xml
+++ b/pom.xml
@@ -87,8 +87,8 @@
     <maven.gpg.plugin.version>1.6</maven.gpg.plugin.version>
 
     <!-- Builder dependencies versions -->
-    <j2cl.version>0.11.0-9336533b6</j2cl.version>
-    <closure.compiler.unshaded.version>v20221102-1</closure.compiler.unshaded.version>
+    <j2cl.version>v20230718-1</j2cl.version>
+    <closure.compiler.unshaded.version>v20230411-1</closure.compiler.unshaded.version>
     <commons.codec.version>1.11</commons.codec.version>
     <commons.io.version>2.7</commons.io.version>
 
@@ -115,7 +115,7 @@
     <jetty.version>9.4.43.v20210629</jetty.version>
 
     <!-- Required core j2cl dependencies -->
-    <vertispan.jsinterop.base.version>1.0.0-1</vertispan.jsinterop.base.version>
+    <vertispan.jsinterop.base.version>1.0.1-1</vertispan.jsinterop.base.version>
 
     <!-- Configurations -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Now using latest tagged j2cl, jsinterop-base, and the closure-compiler version that j2cl depends on.

Also updates elemental2 test to ensure the latest release works with the plugin.

Fixes #234