### PR TITLE
Rough draft of bundling sourcemaps and original sources

### DIFF
--- a/j2cl-tasks/src/main/java/com/vertispan/j2cl/build/provided/BundleJarTask.java
+++ b/j2cl-tasks/src/main/java/com/vertispan/j2cl/build/provided/BundleJarTask.java
@@ -5,13 +5,10 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.javascript.jscomp.deps.ClosureBundler;
 import com.vertispan.j2cl.build.task.*;
-import com.vertispan.j2cl.tools.Closure;
-import org.apache.commons.io.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
@@ -53,7 +50,7 @@ public class BundleJarTask extends TaskFactory {
                                 .map(inputs(OutputTypes.BUNDLED_JS)),
                         Stream.of(input(project, OutputTypes.BUNDLED_JS))
                 )
-                .map(i -> i.filter(BUNDLE_JS))
+                .map(i -> i.filter(BUNDLE_JS, withSuffix(".bundle.js.map")))
                 .collect(Collectors.toUnmodifiableList());
 
         // Sort the projects, to try to include them in order. We can't be sure that all project
@@ -113,12 +110,12 @@ public class BundleJarTask extends TaskFactory {
                     Files.copy(bundle.getAbsolutePath(), targetFile, StandardCopyOption.REPLACE_EXISTING);
                 }
 
-                File destSourcesDir = outputDir.toPath().resolve(Closure.SOURCES_DIRECTORY_NAME).toFile();
-                destSourcesDir.mkdirs();
-                for (Path dir : jsSources.stream().map(Input::getParentPaths).flatMap(Collection::stream).map(p -> p.resolve(Closure
-                        .SOURCES_DIRECTORY_NAME)).collect(Collectors.toSet())) {
-                    FileUtils.copyDirectory(dir.toFile(), destSourcesDir);
-                }
+//                File destSourcesDir = outputDir.toPath().resolve(Closure.SOURCES_DIRECTORY_NAME).toFile();
+//                destSourcesDir.mkdirs();
+//                for (Path dir : jsSources.stream().map(Input::getParentPaths).flatMap(Collection::stream).map(p -> p.resolve(Closure
+//                        .SOURCES_DIRECTORY_NAME)).collect(Collectors.toSet())) {
+//                    FileUtils.copyDirectory(dir.toFile(), destSourcesDir);
+//                }
 
                 try {
                     Gson gson = new GsonBuilder().setPrettyPrinting().create();
@@ -126,6 +123,7 @@ public class BundleJarTask extends TaskFactory {
                             .flatMap(i -> i.getFilesAndHashes().stream())
                             .map(CachedPath::getSourcePath)
                             .map(Path::toString)
+                            .filter(s -> s.endsWith(".js"))
                             .collect(Collectors.toUnmodifiableList())
                     );
                     // unconditionally set this to false, so that our dependency order works, since we're always in BUNDLE now


### PR DESCRIPTION
This will cost extra CPU time, but save on IO time and disk space, which is likely a net win for most builds. This is a first draft, which appears to work as expected (sourcemaps function correctly, vastly smaller output in BUNDLE_JAR), but doesn't yet fully reduce the number of copies we can make, and doesn't avoid copying sourcemap bundles (in cases where js bundles are not copied). There may also be caching issues, where sourcemaps are incorrect not generated or are regenerated.