### PR TITLE
Remove ability for Turbine to fall back to old implementation

### DIFF
--- a/j2cl-tasks/src/main/java/com/vertispan/j2cl/build/provided/IJarTask.java
+++ b/j2cl-tasks/src/main/java/com/vertispan/j2cl/build/provided/IJarTask.java
@@ -22,10 +22,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 /**
- * TODO implement using the ijar tool or the equivelent
- *
- * For now, this is just the same output, straight passthru
+ * Along with {@link JavacTask}, no longer used unless specifically requested by the user.
+ * See {@link TurbineTask} for the more efficient replacement.
+ * <p>
+ * To re-enable this, set task type stripped_bytecode_headers to "original-bytecode".
  */
+@Deprecated
 @AutoService(TaskFactory.class)
 public class IJarTask extends TaskFactory {
     @Override

--- a/j2cl-tasks/src/main/java/com/vertispan/j2cl/build/provided/JavacTask.java
+++ b/j2cl-tasks/src/main/java/com/vertispan/j2cl/build/provided/JavacTask.java
@@ -29,6 +29,12 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+/**
+ * Along with {@link IJarTask}, no longer used unless specifically requested by the user.
+ * See {@link TurbineTask} for the more efficient replacement. This class was an intermediate
+ * task, before IJarTask, re-enable that class through configuration to use this.
+ */
+@Deprecated
 @AutoService(TaskFactory.class)
 public class JavacTask extends TaskFactory {
 

--- a/j2cl-tasks/src/main/java/com/vertispan/j2cl/build/provided/TurbineTask.java
+++ b/j2cl-tasks/src/main/java/com/vertispan/j2cl/build/provided/TurbineTask.java
@@ -36,9 +36,10 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 @AutoService(TaskFactory.class)
-public class TurbineTask extends JavacTask {
+public class TurbineTask extends TaskFactory {
 
     public static final PathMatcher JAVA_SOURCES = withSuffix(".java");
+    public static final PathMatcher JAVA_BYTECODE = withSuffix(".class");
 
     @Override
     public String getOutputType() {
@@ -57,11 +58,6 @@ public class TurbineTask extends JavacTask {
 
     @Override
     public Task resolve(Project project, Config config) {
-        int version = SourceVersion.latestSupported().ordinal();
-        if(version == 8) {
-            return super.resolve(project, config);
-        }
-
         // emits only stripped bytecode, so we're not worried about anything other than .java files to compile and .class on the classpath
         Input ownSources = input(project, OutputTypes.STRIPPED_SOURCES).filter(JAVA_SOURCES);
 


### PR DESCRIPTION
Formally deprecates old unused tasks that Turbine does for us now.