### PR TITLE
Do not compile reactor annotation processors with the j2cl

### DIFF
--- a/build-caching/src/main/java/com/vertispan/j2cl/build/task/TaskFactory.java
+++ b/build-caching/src/main/java/com/vertispan/j2cl/build/task/TaskFactory.java
@@ -34,6 +34,8 @@ public abstract class TaskFactory {
         };
     }
 
+    protected final static Path annotationProcessorPath = Path.of("META-INF", "services", "javax.annotation.processing.Processor");
+
     public final List<com.vertispan.j2cl.build.Input> inputs = new ArrayList<>();
 
     protected Input input(Dependency dependency, String outputType) {

--- a/j2cl-tasks/src/main/java/com/vertispan/j2cl/build/provided/BytecodeTask.java
+++ b/j2cl-tasks/src/main/java/com/vertispan/j2cl/build/provided/BytecodeTask.java
@@ -6,15 +6,11 @@ import com.vertispan.j2cl.build.task.*;
 import com.vertispan.j2cl.tools.Javac;
 
 import javax.annotation.Nullable;
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -39,7 +35,7 @@ public class BytecodeTask extends TaskFactory {
     public static final PathMatcher NOT_BYTECODE = p -> !JAVA_BYTECODE.matches(p);
 
     public static final PathMatcher APT_PROCESSOR = p ->
-                        p.equals(Paths.get("META-INF", "services", "javax.annotation.processing.Processor"));
+                        p.equals(annotationProcessorPath);
 
     @Override
     public String getOutputType() {

--- a/j2cl-tasks/src/main/java/com/vertispan/j2cl/build/provided/J2clTask.java
+++ b/j2cl-tasks/src/main/java/com/vertispan/j2cl/build/provided/J2clTask.java
@@ -6,6 +6,7 @@ import com.vertispan.j2cl.build.task.*;
 import com.vertispan.j2cl.tools.J2cl;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.util.Collections;
@@ -38,8 +39,9 @@ public class J2clTask extends TaskFactory {
     @Override
     public Task resolve(Project project, Config config) {
         // J2CL is only interested in .java and .native.js files in our own sources
+        Input ownJavaBytecode = input(project, OutputTypes.BYTECODE);
         Input ownJavaSources = input(project, OutputTypes.STRIPPED_SOURCES).filter(JAVA_SOURCES, NATIVE_JS_SOURCES);
-        List<Input> ownNativeJsSources = Collections.singletonList(input(project, OutputTypes.BYTECODE).filter(NATIVE_JS_SOURCES));
+        List<Input> ownNativeJsSources = Collections.singletonList(ownJavaBytecode.filter(NATIVE_JS_SOURCES));
 
         // From our classpath, j2cl is only interested in our compile classpath's bytecode
         List<Input> classpathHeaders = scope(project.getDependencies().stream()
@@ -62,6 +64,14 @@ public class J2clTask extends TaskFactory {
                     extraClasspath.stream()
             )
                     .collect(Collectors.toUnmodifiableList());
+
+            if(ownJavaBytecode.getProject().hasSourcesMapped()) {
+                for (Path p : ownJavaBytecode.getParentPaths()) {
+                    if(Files.exists(p.resolve(annotationProcessorPath))) {
+                        return;
+                    }
+                }
+            }
 
             J2cl j2cl = new J2cl(classpathDirs, bootstrapClasspath, context.outputPath().toFile(), context);
 

--- a/j2cl-tasks/src/main/java/com/vertispan/j2cl/build/provided/StripSourcesTask.java
+++ b/j2cl-tasks/src/main/java/com/vertispan/j2cl/build/provided/StripSourcesTask.java
@@ -66,6 +66,15 @@ public class StripSourcesTask extends TaskFactory {
                     filesToProcess.add(makeFileInfo(path));
                 }
             }
+
+            if(inputSources.getProject().hasSourcesMapped()) {
+                for (Path p : inputSources.getParentPaths()) {
+                    if(Files.exists(p.resolve(annotationProcessorPath))) {
+                        return;
+                    }
+                }
+            }
+
             GwtIncompatiblePreprocessor preprocessor = new GwtIncompatiblePreprocessor(context.outputPath().toFile(), context);
             preprocessor.preprocess(filesToProcess);
         };


### PR DESCRIPTION
There is no need to compile reactor annotation processors, so the building will be a little faster and, what is really nice, there will be no error messages in the logs.