### PR TITLE
bump turbine to 0.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
     <error.prone.annotations.version>2.1.3</error.prone.annotations.version>
     <jsr305.version>3.0.2</jsr305.version>
     <commons.lang3.version>3.8.1</commons.lang3.version>
-    <google.turbine.version>0.2.1</google.turbine.version>
+    <google.turbine.version>0.6.0</google.turbine.version>
     <slf4j.api.version>1.7.5</slf4j.api.version>
 
     <!-- Test goal -->


### PR DESCRIPTION
the latest turbine still has 8 source/target java levels, so there must be no issues